### PR TITLE
rename spike-base to spike-tpl-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "spike-base",
+  "name": "spike-tpl-base",
   "description": "Base template for latest spike version",
   "version": "0.0.0",
   "author": "Carrot Creative",
   "ava": {
     "verbose": "true"
   },
-  "bugs": "https://github.com/static-dev/spike-base/issues",
+  "bugs": "https://github.com/static-dev/spike-tpl-base/issues",
   "devDependencies": {
     "ava": "^0.14.0",
     "os-tmpdir": "^1.0.1",
@@ -15,7 +15,7 @@
     "sprout": "1.x",
     "when": "^3.7.7"
   },
-  "homepage": "https://github.com/static-dev/spike-base",
+  "homepage": "https://github.com/static-dev/spike-tpl-base",
   "keywords": [
     "spike",
     "spike-template",
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "main": "init.js",
-  "repository": "https://github.com/static-dev/spike-base",
+  "repository": "https://github.com/static-dev/spike-tpl-base",
   "scripts": {
     "test": "ava"
   }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Spike - Base Template
 
-[![tests](http://img.shields.io/travis/static-dev/spike-base/master.svg?style=flat)](https://travis-ci.org/spike-base/spike-base) [![dependencies](http://david-dm.org/static-dev/spike-base.svg?path=root)](https://david-dm.org/static-dev/spike-base?path=root)
+[![tests](http://img.shields.io/travis/static-dev/spike-tpl-base/master.svg?style=flat)](https://travis-ci.org/spike-tpl-base/spike-tpl-base) [![dependencies](http://david-dm.org/static-dev/spike-tpl-base.svg?path=root)](https://david-dm.org/static-dev/spike-tpl-base?path=root)
 
 The base template for the latest [spike](https://github.com/static-dev/spike) version. The features in this template are designed by the [carrot](https://github.com/carrot) tech team.
 
@@ -18,8 +18,8 @@ This is the default template for use within [spike](https://github.com/static-de
 [Spike](https://github.com/static-dev/spike) uses [sprout](https://github.com/carrot/sprout) internally to generate it's project templates. This means you can even use this template without [spike](https://github.com/static-dev/spike) by using [sprout](https://github.com/carrot/sprout) directly.
 
 - `npm i sprout-cli -g`
-- `sprout add spike-base git@github.com:static-dev/spike-base.git`
-- `sprout new spike-base <myproject>`
+- `sprout add spike-tpl-base git@github.com:static-dev/spike-tpl-base.git`
+- `sprout new spike-tpl-base <myproject>`
 
 ## Options
 

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ test.cb.before((t) => {
 })
 
 test('initializes with sprout, compiles with spike', t => {
-  const tplName = 'spike-base-test'
+  const tplName = 'spike-tpl-base-test'
   const locals = { name: 'doge', description: 'wow', github_username: 'amaze' }
   const sprout = new Sprout(tmpdir())
 


### PR DESCRIPTION
we'll create a naming convention of `spike-tpl-*` for spike templates, to avoid any confusion with `spike-*` plugins/core modules. 